### PR TITLE
Fixed bav not working on other SDK types

### DIFF
--- a/src/BumpAssemblyVersions/BumpVersionTask.cs
+++ b/src/BumpAssemblyVersions/BumpVersionTask.cs
@@ -302,8 +302,7 @@ namespace Bav
             if (TryReadingFile(projectFilename, out var given)
                 && TryParseDocument(given, out var givenDoc,
                     root => root?.Name.LocalName == "Project"
-                            && root.Attribute("Sdk") is XAttribute a
-                            && a.Value == "Microsoft.NET.Sdk"))
+                            && root.Attribute("Sdk") is XAttribute a))
             {
                 /* Process the Given Doc using the Services in the Aggregate.
                  Pull the Tried Doc forward when the Bump did Try. */


### PR DESCRIPTION
Removed a hardcoded filter on sdk type that was preventing the bav task from bumping the version on other sdk types, like Microsoft.NET.Sdk, Microsoft.NET.Sdk.WindowsDesktop, and Microsoft.NET.Sdk.Worker.  Resolves issue #6 